### PR TITLE
Build on systems with split ncurses/tinfo libraries

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -12,12 +12,6 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
-/* Define to 1 if you have the `ncurses' library (-lncurses). */
-#undef HAVE_LIBNCURSES
-
-/* Define to 1 if you have the `panel' library (-lpanel). */
-#undef HAVE_LIBPANEL
-
 /* Define to 1 if you have the <limits.h> header file. */
 #undef HAVE_LIMITS_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -30,9 +30,11 @@ AC_PROG_CXX
 AC_PROG_CC
 
 # Checks for libraries.
-AC_CHECK_LIB([ncurses], [initscr], ,
+AC_SEARCH_LIBS([initscr], [ncurses], ,
              [AC_MSG_ERROR([The ncurses library is required])])
-AC_CHECK_LIB([panel], [new_panel], ,
+AC_SEARCH_LIBS([cbreak], [ncurses tinfo], ,
+             [AC_MSG_ERROR([The ncurses/tinfo library is required])])
+AC_SEARCH_LIBS([new_panel], [panel], ,
              [AC_MSG_ERROR([The panel library is required])])
 
 # Checks for header files.


### PR DESCRIPTION
Building fails on systems with split ncurses/tinfo libraries with the following error:

```
ld: ConWin.o: undefined reference to symbol 'cbreak'
```

Indeed, in such setups `cbreak` is not defined in libncurses but in libtinfo.
This should be detected and handled in `configure.ac`.
