### PR TITLE
handle SIGINT

### DIFF
--- a/vbindiff.cpp
+++ b/vbindiff.cpp
@@ -25,6 +25,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+#include <signal.h>
 
 #include <algorithm>
 #include <iostream>
@@ -1816,6 +1817,13 @@ void processOptions(int& argc, char**& argv)
   }
 } // end processOptions
 
+static int ctrlc_pressed;
+
+static void sighandler(int signo) {
+	(void) signo;
+	ctrlc_pressed = 1;
+}
+
 //====================================================================
 // Main Program:
 //====================================================================
@@ -1863,8 +1871,10 @@ VBinDiff comes with ABSOLUTELY NO WARRANTY; for details type `vbindiff -L'.\n";
   file1.display();
   file2.display();
 
+  signal(SIGINT, sighandler);
+
   Command  cmd;
-  while ((cmd = getCommand()) != cmQuit)
+  while (!ctrlc_pressed && (cmd = getCommand()) != cmQuit)
     handleCmd(cmd);
 
   file1.shutDown();


### PR DESCRIPTION
many ncurses programs such as hexedit use SIGINT (CTRL-C) as the
command to shut down the application, but when one does the same
with vbindiff, the terminal modes are not properly reset, leaving
a messed up terminal that can not even be restored completely with
`reset` command.
so practically everytime i used vbindiff, this happened to me,
accompanied by a "sh... it happened again".