### PR TITLE
Handle 'panel.h' being in an 'ncurses' directory

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -21,6 +21,9 @@
 /* Define to 1 if you have the `memset' function. */
 #undef HAVE_MEMSET
 
+/* Define to 1 if you have the <ncurses/panel.h> header file. */
+#undef HAVE_NCURSES_PANEL_H
+
 /* Define to 1 if you have the <panel.h> header file. */
 #undef HAVE_PANEL_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ AC_SEARCH_LIBS([new_panel], [panel], ,
 
 # Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS([errno.h fcntl.h limits.h panel.h stdlib.h string.h unistd.h])
+AC_CHECK_HEADERS([errno.h fcntl.h limits.h panel.h ncurses/panel.h stdlib.h string.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL

--- a/curses/ConWin.hpp
+++ b/curses/ConWin.hpp
@@ -23,7 +23,14 @@
 
 #define INCLUDED_CONWIN_HPP
 
+#include "config.h"
+#if defined(HAVE_PANEL_H)
 #include <panel.h>
+#elif defined(HAVE_NCURSES_PANEL_H)
+#include <ncurses/panel.h>
+#else
+#error "Couldn't find a panel.h header."
+#endif
 #undef border                 // It interferes with my member function
 
 #define KEY_ESCAPE 0x1B


### PR DESCRIPTION
Some Linux distributions (such as OpenSUSE) do not keep the ncurses ``panel.h`` file in the default include path, but rather in a
subdirectory.

Update the ``configure`` script and ``curses/ConWin.hpp`` file to look in both places for a ``panel.h`` file. ``panel.h`` is still preferred over
``ncurses/panel.h``, as we expect other ncurses headers to be in the include path.

(I'm neither a curses expert nor an autotools expert, so there's probably a better way of doing this. But this is probably better than nothing, and seems to roughly match [what lldb did](https://reviews.llvm.org/D85219).)

This seems to have already been filed as issue #18 — which I really should've looked at before writing this. :-)